### PR TITLE
Add subtitle settings panel to sample where the subtitle selection is on root level

### DIFF
--- a/playerUi/separatedAudioSubtitleSettings.html
+++ b/playerUi/separatedAudioSubtitleSettings.html
@@ -258,8 +258,8 @@
 
         subtitleSettingsPanel.addComponent(
             new bitmovin.playerui.SettingsPanelItem(
+                null,
                 new bitmovin.playerui.subtitlesettings.SubtitleSettingsLabel({ text: 'Settings', opener: subtitleCustomizationOpenButton }),
-                new bitmovin.playerui.Spacer(), // The Spacer is used to add an empty component to the SettingsPanelItem
                 { cssClasses: ['subtitle-customization-settings-panel-item'] }
             )
         );

--- a/playerUi/separatedAudioSubtitleSettings.html
+++ b/playerUi/separatedAudioSubtitleSettings.html
@@ -176,6 +176,9 @@
             -webkit-filter: none;
         }
 
+        .bmpui-ui-skin-modern .bmpui-subtitle-customization-settings-panel-item {
+            text-align: center;
+        }
 
     </style>
 </head>
@@ -242,6 +245,25 @@
             hidden: true,
         });
 
+        var subtitleCustomizationSettingsPanel = new bitmovin.playerui.subtitlesettings.SubtitleSettingsPanel({
+            hidden: true,
+            overlay: subtitleOverlay,
+            settingsPanel: subtitleSettingsPanel,
+        });
+
+        var subtitleCustomizationOpenButton = new bitmovin.playerui.subtitlesettings.SubtitleSettingsOpenButton({
+            subtitleSettingsPanel: subtitleCustomizationSettingsPanel,
+            settingsPanel: subtitleSettingsPanel,
+        });
+
+        subtitleSettingsPanel.addComponent(
+            new bitmovin.playerui.SettingsPanelItem(
+                new bitmovin.playerui.subtitlesettings.SubtitleSettingsLabel({ text: 'Settings', opener: subtitleCustomizationOpenButton }),
+                new bitmovin.playerui.Spacer(), // The Spacer is used to add an empty component to the SettingsPanelItem
+                { cssClasses: ['subtitle-customization-settings-panel-item'] }
+            )
+        );
+
         var audioTrackListBox = new bitmovin.playerui.AudioTrackListBox();
         var audioTrackSettingsPanel = new bitmovin.playerui.SettingsPanel({
             components: [
@@ -254,6 +276,7 @@
             components: [
                 audioTrackSettingsPanel,
                 subtitleSettingsPanel,
+                subtitleCustomizationSettingsPanel,
                 settingsPanel,
                 new bitmovin.playerui.Container({
                     components: [


### PR DESCRIPTION
## Description
Since we add the sample how to extract subtitle selection form the settings panel to the root level we lost the option to customize the subtitle appearance. This PR will update the sample how the customization settings can be added.