### PR TITLE
Update chromecast link in web samples

### DIFF
--- a/castReceiver/index.html
+++ b/castReceiver/index.html
@@ -8,7 +8,7 @@
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400" rel="stylesheet">
     <link rel="icon" type="image/png" href="../images/bit-fav.png">
     <!-- Bitmovin Player -->
-    <script src="//cdn.bitmovin.com/player/web/8.5.0/bitmovinplayer.js"></script>
+    <script src="//cdn.bitmovin.com/player/web/8/bitmovinplayer.js"></script>
     <style>
         body {
             margin: 0;

--- a/castReceiver/receiverApp.html
+++ b/castReceiver/receiverApp.html
@@ -91,7 +91,7 @@
 <script type="text/javascript" src="//www.gstatic.com/cast/sdk/libs/receiver/2.0.0/cast_receiver.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.2/require.js" integrity="sha256-uvyqD81XGEqlTzEGkl+5L73IUlWTXtdLhfnUG5n3FbE="
         crossorigin="anonymous"></script>
-<script type="text/javascript" src="https://cdn.bitmovin.com/player/cast/8.1.0/bitmovinplayer-remotereceiver.js"></script>
+<script type="text/javascript" src="https://cdn.bitmovin.com/player/cast/8.14.1-2/bitmovinplayer-remotereceiver.js"></script>
 <script type="text/javascript">
 
   // Hide app loading overlay

--- a/castReceiver/receiverApp.html
+++ b/castReceiver/receiverApp.html
@@ -91,7 +91,7 @@
 <script type="text/javascript" src="//www.gstatic.com/cast/sdk/libs/receiver/2.0.0/cast_receiver.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.2/require.js" integrity="sha256-uvyqD81XGEqlTzEGkl+5L73IUlWTXtdLhfnUG5n3FbE="
         crossorigin="anonymous"></script>
-<script type="text/javascript" src="https://cdn.bitmovin.com/player/cast/8.14.1-2/bitmovinplayer-remotereceiver.js"></script>
+<script type="text/javascript" src="bitmovinplayer-remotereceiver.js"></script>
 <script type="text/javascript">
 
   // Hide app loading overlay

--- a/castReceiver/receiverApp.html
+++ b/castReceiver/receiverApp.html
@@ -91,7 +91,7 @@
 <script type="text/javascript" src="//www.gstatic.com/cast/sdk/libs/receiver/2.0.0/cast_receiver.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.2/require.js" integrity="sha256-uvyqD81XGEqlTzEGkl+5L73IUlWTXtdLhfnUG5n3FbE="
         crossorigin="anonymous"></script>
-<script type="text/javascript" src="bitmovinplayer-remotereceiver.js"></script>
+<script type="text/javascript" src="https://cdn.bitmovin.com/player/cast/8.14.1-2/bitmovinplayer-remotereceiver.js"></script>
 <script type="text/javascript">
 
   // Hide app loading overlay


### PR DESCRIPTION
### Problem
The chromecast receiver app version was outdated. 

### Fix
Replaced it with a relative URL to avoid these situations in the future. 