### PR TITLE
bug: bundling issue with `vite`

### DIFF
--- a/modular-player/webpack/index.html
+++ b/modular-player/webpack/index.html
@@ -125,6 +125,6 @@
         </div>
     </div>
 </div>
-<script type="text/javascript" src="./dist/bundle.js"></script>
+<script type='module' src='/src/index.js'></script>
 </body>
 </html>

--- a/modular-player/webpack/package.json
+++ b/modular-player/webpack/package.json
@@ -1,8 +1,14 @@
 {
+  "scripts": {
+    "build": "vite build",
+    "serve": "vite preview",
+    "dev": "vite"
+  },
   "devDependencies": {
     "bitmovin-player": "^8.0.1",
     "css-loader": "^1.0.0",
     "style-loader": "^0.23.0",
+    "vite": "^2.5.7",
     "webpack": "^4.17.1",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.6"

--- a/modular-player/webpack/src/index.js
+++ b/modular-player/webpack/src/index.js
@@ -8,6 +8,10 @@ import SubtitlesModule from 'bitmovin-player/modules/bitmovinplayer-subtitles';
 import SubtitlesCEA608Module from 'bitmovin-player/modules/bitmovinplayer-subtitles-cea608';
 import PolyfillModule from 'bitmovin-player/modules/bitmovinplayer-polyfill';
 import StyleModule from 'bitmovin-player/modules/bitmovinplayer-style';
+import XMLModule from 'bitmovin-player/modules/bitmovinplayer-xml';
+import DashModule from 'bitmovin-player/modules/bitmovinplayer-dash';
+import MP4ContainerModule from 'bitmovin-player/modules/bitmovinplayer-container-mp4';
+
 
 import { UIFactory } from 'bitmovin-player/bitmovinplayer-ui';
 import 'bitmovin-player/bitmovinplayer-ui.css';
@@ -17,10 +21,13 @@ Player.addModule(MseRendererModule);
 Player.addModule(HlsModule);
 Player.addModule(AbrModule);
 Player.addModule(ContainerTSModule);
+Player.addModule(MP4ContainerModule);
 Player.addModule(SubtitlesModule);
 Player.addModule(SubtitlesCEA608Module);
 Player.addModule(PolyfillModule);
 Player.addModule(StyleModule);
+Player.addModule(XMLModule);
+Player.addModule(DashModule);
 
 const conf = {
     key: 'YOUR KEY HERE',

--- a/modular-player/webpack/vite.config.ts
+++ b/modular-player/webpack/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig, PluginOption, UserConfigExport } from 'vite';
+
+
+// https://vitejs.dev/config/
+
+
+export default defineConfig({
+    plugins: [],
+    base: '',
+});


### PR DESCRIPTION
- this PR shows a bug where bundling with `vite` (which uses `rollup` under the hood) causes issues when using the modular player
- to repro do the following
  ```
  npm run build
  npm run serve
  ```
- access the server at http://localhost:5000/
- check the error in the browser console
  ```
  {
    "code": 3001,
    "name": "MODULE_INVALID_DEFINITION",
    "message": "Missing name",
    "data": null
}
  ```