### PR TITLE
Add samples to drop all EMSG boxes from segment

### DIFF
--- a/ps5/dropAllConsecutiveEmsgBox.html
+++ b/ps5/dropAllConsecutiveEmsgBox.html
@@ -87,7 +87,7 @@
   };
 
     var source = {
-      "hls": "https://nbalpng.akamaized.net/vod-pz/a/hls-itc/NBA_g0022200001phi1000446bosV/index.m3u8"
+      hls: 'https://bitmovin-player-eu-west1-ci-input.s3.amazonaws.com/general/emsg_v1/master.m3u8'
     };
 
     function processSegment(segmentData) {

--- a/ps5/dropAllConsecutiveEmsgBox.html
+++ b/ps5/dropAllConsecutiveEmsgBox.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+   <title>Bitmovin Player Demo</title>
+   <meta charset="UTF-8"/>
+   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+   <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/bitmovinplayer.js"></script>
+   <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/codem-isoboxer@0.3.7/dist/iso_boxer.min.js"></script>
+   <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-playstation5.js"></script>
+   <style>
+     #player {
+       width: 95%;
+       margin: 20px auto;
+       box-shadow: 0 0 30px rgba(0,0,0,0.7);
+     }
+   </style>
+ </head>
+ <body>
+ <div id="player"></div>
+<script type="text/javascript">
+  /**
+   * This example assumes that the EMSG boxes in the segments are consective.
+   * The data sample for EMSG boxes are removed from the segment data and a new
+   * segment data is created.
+   */
+
+  function arrayBufferToBase64(arrayBuffer) {
+    return btoa(String.fromCodePoint(...new Uint8Array(arrayBuffer)));
+  }
+
+  function base64ToArrayBuffer(base64) {
+    const binaryString = window.atob(base64);
+    const length = binaryString.length;
+    const bytes = new Uint8Array(length);
+    for (let i = 0; i < length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+
+    return bytes.buffer;
+  }
+
+  function onMetadataEvent (event) {
+    console.log('onMetadata : type=' + event.metadataType);
+  }
+
+  var bufferConfig = {};
+  var bufferLevels = {};
+
+  bufferLevels['forwardduration'] = 12;
+  bufferLevels['backwardduration'] = 12,
+
+  bufferConfig['video'] = bufferLevels;
+  bufferConfig['audio'] = bufferLevels;
+
+  var conf = { 
+    key: 'YOUR KEY HERE',
+    playback: {
+      autoplay: true,
+      muted: true
+    },
+    network: {
+      preprocessHttpResponse: (type, response) => {
+        if ([bitmovin.player.HttpRequestType.MEDIA_VIDEO].indexOf(type) > -1) {
+          response.body = processSegment(response.body);
+          checkEMSGStatus(response.body)
+        }
+
+        return Promise.resolve(response);
+      }
+    },
+    buffer: bufferConfig,
+    logs: {
+      level: 'debug'
+    },
+    events: {
+      metadata: onMetadataEvent,
+    },
+    tweaks: {
+      file_protocol: true,
+      BACKWARD_BUFFER_PURGE_INTERVAL: 10,
+      enable_seek_for_live: true,
+      fairplay_ignore_duplicate_init_data_key_errors: true,
+      startup_threshold: 4,
+      restart_threshold: 4
+    },
+  };
+
+    var source = {
+      "hls": "https://nbalpng.akamaized.net/vod-pz/a/hls-itc/NBA_g0022200001phi1000446bosV/index.m3u8"
+    };
+
+    function processSegment(segmentData) {
+      var isoFile = ISOBoxer.parseBuffer(segmentData);
+      const emsgList = isoFile.fetchAll('emsg');
+      console.debug('EMSG count=' + emsgList.length);
+
+      if (emsgList.length > 0) {
+        var startTime = Math.floor(Date.now());
+        console.log ('Starting EMSG drop logic: startTime=:' + startTime);
+
+        var firstEmsgOffset = 0;
+        var totalEmsgSize = 0;
+        emsgList.forEach(function(emsg) {
+          if (firstEmsgOffset === 0) {
+            firstEmsgOffset = emsg._offset;
+          }
+
+          if (emsg._offset !== (firstEmsgOffset + totalEmsgSize)) {
+            console.error ('EMSG boxes not consecutive, assumption is incorrect');
+          }
+
+          totalEmsgSize = totalEmsgSize + emsg.size;
+        });
+
+        segmentData = rewriteSegment(segmentData, firstEmsgOffset, totalEmsgSize);
+        var endTime = Math.floor(Date.now());
+        console.log ('Dropped ' + (emsgList.length) + ' EMSG boxes in ' + (endTime-startTime) + ' milliseconds' + ', endTime=' + endTime);
+      }
+
+      return segmentData;
+    }
+
+    function rewriteSegment(buffer, trimOffset, trimSize) {
+      console.log('Rewriting segment to drop EMSG boxes');
+      const original = new Uint8Array(buffer);
+      const newBuf = new Uint8Array(buffer.byteLength - trimSize);
+
+      // Only take the segment data that is before and after the EMSG boxes.
+      newBuf.set(original.subarray(0, trimOffset), 0);
+      newBuf.set(original.subarray(trimOffset + trimSize), trimOffset);
+
+      return newBuf.buffer;
+    }
+
+    function checkEMSGStatus(segmentData) {
+      var isoFile = ISOBoxer.parseBuffer(segmentData);
+      const emsgList = isoFile.fetchAll('emsg');
+      console.debug('EMSG count in processed segment=' + emsgList.length);
+      if (emsgList.lenght > 0) {
+        console.warn('EMSGs still present:(');
+      } else {
+        console.log('Successfully dropped EMSGs');
+      }
+    }
+
+    bitmovin.player.Player.addModule(bitmovin.player.playstation5.default);
+    var player = new bitmovin.player.Player(document.getElementById('player'), conf);
+
+    player.load(source);
+</script>

--- a/ps5/dropAllEmsgBox.html
+++ b/ps5/dropAllEmsgBox.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+   <title>Bitmovin Player Demo</title>
+   <meta charset="UTF-8"/>
+   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+   <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8.92.2/bitmovinplayer.js"></script>
+   <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/codem-isoboxer@0.3.7/dist/iso_boxer.min.js"></script>
+   <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8.92.2/modules/bitmovinplayer-playstation5.js"></script>
+   <style>
+     #player {
+       width: 95%;
+       margin: 20px auto;
+       box-shadow: 0 0 30px rgba(0,0,0,0.7);
+     }
+   </style>
+</head>
+<body>
+<div id="player"></div>
+<script type="text/javascript"> 
+  function arrayBufferToBase64(arrayBuffer) {
+    return btoa(String.fromCodePoint(...new Uint8Array(arrayBuffer)));
+  }
+
+  function base64ToArrayBuffer(base64) {
+    const binaryString = window.atob(base64);
+    const length = binaryString.length;
+    const bytes = new Uint8Array(length);
+
+    for (let i = 0; i < length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+
+    return bytes.buffer;
+  }
+
+  var bufferConfig = {};
+  var bufferLevels = {};
+
+  bufferLevels['forwardduration'] = 12;
+  bufferLevels['backwardduration'] = 12,
+  bufferConfig['video'] = bufferLevels;
+  bufferConfig['audio'] = bufferLevels;
+
+  var conf = {
+    key: 'YOUR KEY HERE',
+    playback: {
+      autoplay: true,
+      muted: true
+    },
+    network: {
+      preprocessHttpResponse: (type, response) => {
+        if ([bitmovin.player.HttpRequestType.MEDIA_VIDEO].indexOf(type) > -1) {
+          response.body = processSegment(response.body);
+          checkEMSGStatus(response.body)
+        }
+        return Promise.resolve(response);
+      }
+    },
+    buffer: bufferConfig,
+    logs: {
+      level: 'debug'
+    },
+    events: {
+      metadata: onMetadataEvent,
+    },
+    tweaks: {
+      file_protocol: true,
+      BACKWARD_BUFFER_PURGE_INTERVAL: 10,
+      enable_seek_for_live: true,
+      fairplay_ignore_duplicate_init_data_key_errors: true,
+      startup_threshold: 4,
+      restart_threshold: 4
+    },
+  };
+
+    var source = {
+      "hls": "https://nbalpng.akamaized.net/vod-pz/a/hls-itc/NBA_g0022200001phi1000446bosV/index.m3u8"
+    };
+
+    function processSegment(segmentData) {
+      var isoFile = ISOBoxer.parseBuffer(segmentData);
+      const emsgList = isoFile.fetchAll('emsg');
+      console.debug('EMSG count(NEW)=' + emsgList.length);
+
+      if (emsgList.length > 0) {
+        var startTime = Math.floor(Date.now());
+        console.log ('Starting EMSG drop logic: startTime=:' + startTime);
+        for (var i = (emsgList.length - 1); i >= 0; i--) {
+          segmentData = this.dropEMSGBox(segmentData, emsgList[i]);
+        }
+        var endTime = Math.floor(Date.now());
+        console.log ('Finishing EMSG drop logic: endTime=' + endTime + ', duration=' + (endTime-startTime) + ' milliseconds');
+      }
+      return segmentData;
+    }
+
+    function dropEMSGBox(buffer, box) {
+      if (!box) {
+        return buffer;
+      }
+
+      console.log('Dropping EMSG');
+      const original = new Uint8Array(buffer);
+      const newBuf = new Uint8Array(buffer.byteLength - box.size);
+      newBuf.set(original.subarray(0, box._offset), 0);
+      newBuf.set(original.subarray(box._offset + box.size), box._offset);
+
+      return newBuf.buffer;
+    }
+
+    function checkEMSGStatus(segmentData) {
+      var isoFile = ISOBoxer.parseBuffer(segmentData);
+      const emsgList = isoFile.fetchAll('emsg');
+      console.debug('EMSG count in processed segment=' + emsgList.length);
+      if (emsgList.lenght > 0) {
+        console.warn('EMSGs still present:(');
+      } else {
+        console.log('Successfully dropped EMSGs');
+      }
+    }
+
+    function onMetadataEvent (event) {
+      console.log('onMetadata : type=' + event.metadataType);
+    }
+
+    var player;
+    bitmovin.player.Player.addModule(bitmovin.player.playstation5.default);
+    player = new bitmovin.player.Player(document.getElementById('player'), conf);
+
+    player.load(source);
+</script>

--- a/ps5/dropAllEmsgBox.html
+++ b/ps5/dropAllEmsgBox.html
@@ -76,7 +76,7 @@
   };
 
     var source = {
-      "hls": "https://nbalpng.akamaized.net/vod-pz/a/hls-itc/NBA_g0022200001phi1000446bosV/index.m3u8"
+      hls: 'https://bitmovin-player-eu-west1-ci-input.s3.amazonaws.com/general/emsg_v1/master.m3u8'
     };
 
     function processSegment(segmentData) {


### PR DESCRIPTION
This PR add some sample code to drop all EMSG boxes present in the segment.

There is a limitation on the PS5 that there should not be more than 47 boxes before `mdat`. Having too many EMSG boxes can cause Media decode error.