### PR TITLE
Add multiview / multiplayer sample

### DIFF
--- a/multiview/README.md
+++ b/multiview/README.md
@@ -1,0 +1,3 @@
+# Bitmovin Player MultiView Samples
+
+This folder contains a few samples showcasing how you could achieve a multiview experience in your app using the Bitmovin Player Web SDK.

--- a/multiview/README.md
+++ b/multiview/README.md
@@ -1,3 +1,8 @@
 # Bitmovin Player MultiView Samples
 
-This folder contains a few samples showcasing how you could achieve a multiview experience in your app using the Bitmovin Player Web SDK.
+This folder contains a few samples showcasing how you could achieve a multiview experience using Bitmovin Player Web SDK.
+
+### Multi-Player approach
+The [multiplayer sample](multiplayer.html) shows how you can leverage multiple Bitmovin Player instances to achieve multiview.
+In the sample, one player is always kept predominant but additional players can be added to the multiview. As many as 4 sources can be added and played simultaneously. Players can also be swapped around, e.g. you can drag one of the active player to become the main one, etc.
+This approach could be a viable solution for all browsers that support multiple player instances (i.e. desktop browsers).

--- a/multiview/README.md
+++ b/multiview/README.md
@@ -2,6 +2,8 @@
 
 This folder contains a few samples showcasing how you could achieve a multiview experience using Bitmovin Player Web SDK.
 
+---
+
 ### Multi-Player approach
 The [multiplayer sample](multiplayer.html) shows how you can leverage multiple Bitmovin Player instances to achieve multiview.
 In the sample, one player is always kept predominant while additional players can be added to the multiview. As many as 4 sources can be added and played simultaneously. Players can also be swapped around, e.g. you can drag one of the active player to become the main one, etc.

--- a/multiview/README.md
+++ b/multiview/README.md
@@ -6,5 +6,5 @@ This folder contains a few samples showcasing how you could achieve a multiview 
 
 ### Multi-Player approach
 The [multiplayer sample](multiplayer.html) shows how you can leverage multiple Bitmovin Player instances to achieve multiview.
-In the sample, one player is always kept predominant while additional players can be added to the multiview. As many as 4 sources can be added and played simultaneously. Players can also be swapped around, e.g. you can drag one of the active player to become the main one, etc.
+In the sample, one player is always kept predominant while additional players can be added to the multiview. As many as 4 sources can be added and played simultaneously. Players can also be swapped around, e.g. you can drag one of the active players to become the main one, etc.
 This approach could be a viable solution for all browsers that support multiple player instances (i.e. desktop browsers).

--- a/multiview/README.md
+++ b/multiview/README.md
@@ -4,5 +4,5 @@ This folder contains a few samples showcasing how you could achieve a multiview 
 
 ### Multi-Player approach
 The [multiplayer sample](multiplayer.html) shows how you can leverage multiple Bitmovin Player instances to achieve multiview.
-In the sample, one player is always kept predominant but additional players can be added to the multiview. As many as 4 sources can be added and played simultaneously. Players can also be swapped around, e.g. you can drag one of the active player to become the main one, etc.
+In the sample, one player is always kept predominant while additional players can be added to the multiview. As many as 4 sources can be added and played simultaneously. Players can also be swapped around, e.g. you can drag one of the active player to become the main one, etc.
 This approach could be a viable solution for all browsers that support multiple player instances (i.e. desktop browsers).

--- a/multiview/multiplayer.html
+++ b/multiview/multiplayer.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Bitmovin MultiView Demo</title>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400" rel="stylesheet" />
+    <link rel="icon" type="../image/png" href="../images/bit-fav.png" />
+    <!-- Bitmovin Player -->
+    <script type="text/javascript" src="//cdn.bitmovin.com/player/web/8/bitmovinplayer.js"></script>
+    <script type="text/javascript" src="multiplayer.js"></script>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: 'Open Sans', sans-serif;
+        color: #fff;
+        font-weight: 300;
+        background: rgba(44, 131, 185, 1);
+        background: -moz-linear-gradient(left, rgba(44, 131, 185, 1) 0%, rgba(30, 171, 227, 1) 100%);
+        background: -webkit-gradient(
+          left top,
+          right top,
+          color-stop(0%, rgba(44, 131, 185, 1)),
+          color-stop(100%, rgba(30, 171, 227, 1))
+        );
+        background: -webkit-linear-gradient(left, rgba(44, 131, 185, 1) 0%, rgba(30, 171, 227, 1) 100%);
+        background: -o-linear-gradient(left, rgba(44, 131, 185, 1) 0%, rgba(30, 171, 227, 1) 100%);
+        background: -ms-linear-gradient(left, rgba(44, 131, 185, 1) 0%, rgba(30, 171, 227, 1) 100%);
+        background: linear-gradient(to right, rgba(44, 131, 185, 1) 0%, rgba(30, 171, 227, 1) 100%);
+        filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#2c83b9', endColorstr='#1eabe3', GradientType=1);
+      }
+
+      #wrapper {
+        background: url(../images/logo-bg-demopage.png);
+        height: 100vh;
+      }
+
+      #banner {
+        border-bottom: 1px solid #fff;
+        background-color: #1eabe3;
+        width: 100%;
+      }
+
+      #banner h1 {
+        margin: 0;
+        padding: 30px;
+      }
+
+      .logo {
+        padding: 10px;
+        width: 25%;
+        min-width: 350px;
+        float: left;
+        margin: auto;
+      }
+
+      .title {
+        width: 75%;
+        white-space: nowrap;
+      }
+
+      .clear {
+        clear: both;
+      }
+
+      .container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        height: 90vh;
+        margin: 0;
+      }
+
+      .content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        width: 90vw;
+        max-width: 800px;
+        overflow: hidden;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        font-weight: 300;
+        text-align: center;
+        margin: 35px;
+      }
+
+      #player {
+        margin: auto;
+      }
+
+      a {
+        color: #97d9ef;
+        font-weight: 400;
+        text-decoration: none;
+      }
+
+      a:hover {
+        color: #fff;
+      }
+
+      @media (max-width: 800px) {
+        .logo {
+          width: 100%;
+        }
+
+        .title {
+          display: none;
+        }
+      }
+
+      .grid {
+        display: grid;
+        align-content: center;
+        align-items: center;
+        gap: 5px 10px;
+        width: 100%;
+        height: 100%;
+      }
+      .tile {
+        aspect-ratio: 16/9;
+        border-radius: 10px;
+        overflow: hidden;
+        position: relative;
+      }
+      .tile img {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: 10px;
+      }
+
+      /* Layouts for different tile counts */
+      .grid.tile-count-1 {
+        grid-template-columns: 1fr;
+      }
+      .grid.tile-count-2 {
+        grid-template-columns: 1fr 1fr;
+      }
+      .grid.tile-count-3 {
+        grid-template-columns: 1fr 1fr 1fr;
+        grid-template-areas: 'a a b' 'a a c';
+      }
+      .grid.tile-count-3 > .tile:nth-child(1) {
+        grid-area: a;
+      }
+      .grid.tile-count-3 > .tile:nth-child(2) {
+        grid-area: b;
+      }
+      .grid.tile-count-3 > .tile:nth-child(3) {
+        grid-area: c;
+      }
+      .grid.tile-count-4 {
+        grid-template-columns: 3fr 1fr;
+        grid-template-rows: 1fr 1fr 1fr;
+        grid-template-areas:
+            "a b"
+            "a c"
+            "a d";
+      }
+      .grid.tile-count-4 > .tile:nth-child(1) {
+        grid-area: a;
+      }
+      .grid.tile-count-4 > .tile:nth-child(2) {
+        grid-area: b;
+      }
+      .grid.tile-count-4 > .tile:nth-child(3) {
+        grid-area: c;
+      }
+      .grid.tile-count-4 > .tile:nth-child(4) {
+        grid-area: d;
+      }
+
+      .carousel {
+        display: flex;
+        overflow-x: auto;
+        gap: 10px;
+        padding: 10px 15px;
+        margin: 10px;
+        max-width: 90vw;
+        min-height: 80px;
+        background-color: #fff;
+        border-radius: 10px;
+        box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+      }
+
+      .item {
+        flex: 0 0 150px;
+        aspect-ratio: 16 / 9;
+        position: relative;
+        border-radius: 10px;
+        overflow: hidden;
+        scroll-snap-align: start;
+        cursor: pointer;
+        transition: transform 0.3s, box-shadow 0.3s;
+      }
+      .item img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+      .item:hover {
+        transform: scale(1.05);
+        box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
+      }
+      .item.selected {
+        outline: 2px solid #006aed;
+      }
+      .item .checkmark {
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        width: 18px;
+        height: 18px;
+        color: white;
+        background-color: #006aed;
+        border-radius: 50%;
+        font-size: 0.8em;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        opacity: 0;
+        transition: opacity 0.2s;
+      }
+      .item.selected .checkmark {
+        opacity: 1;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="wrapper">
+      <div id="banner">
+        <div class="logo"><img src="../images/bitmovin-logo.png" /></div>
+        <div class="title"><h1>Bitmovin MultiView Demo</h1></div>
+        <div class="clear"></div>
+      </div>
+      <div class="container">
+        <h2>Achieve multiview playback through a customizable layout.</h2>
+        <div class="content">
+          <div class="grid" id="grid"></div>
+          <div class="carousel" id="carousel"></div>
+          <div class="description">
+            <p>
+              For more information about the bitmovin player, please have a look at our online
+              <a href="//bitmovin.com/support" target="_blank">Developer Section</a>.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/multiview/multiplayer.js
+++ b/multiview/multiplayer.js
@@ -98,6 +98,7 @@ function updateGrid() {
     const player = getPlayerInstance(playerConfig, source);
 
     const tile = player.getContainer();
+    tile.title = source.title;
     grid.appendChild(tile);
   }
 
@@ -134,7 +135,6 @@ function createPlayerTile(source) {
   tile.classList.add('tile');
   tile.id = 'player'; 
   tile.draggable = true;
-  tile.title = source.title;
 
   tile.addEventListener("dragstart", event => {
     if (event.target.id === 'player') {
@@ -149,7 +149,6 @@ function createPlayerTile(source) {
 
     const targetElement = event.target.closest('#player');
     if (draggedElement == null || targetElement == null || draggedElement == targetElement) {
-      console.error('No target or same source');
       return;
     }
 

--- a/multiview/multiplayer.js
+++ b/multiview/multiplayer.js
@@ -105,6 +105,29 @@ function updateGrid() {
   grid.classList.add(`tile-count-${activeSources.length}`);
 }
 
+function getPlayerInstance(playerConfig, source) {
+  let player = reusablePlayers.find(player => player.getSource() === source);
+  if (player) {
+    // An active player instance already exists for this source
+    return player;
+  }
+
+  player = reusablePlayers.find(player => player.getSource() == null);
+  if (player) {
+    // Re-use one of the unused player instances
+    player.load(source);
+    return player;
+  }
+
+  // Create a new player instance
+  const container = createPlayerTile(source);
+  const newPlayer = new bitmovin.player.Player(container, playerConfig);
+  newPlayer.load(source);
+  reusablePlayers.push(newPlayer);
+
+  return newPlayer;
+}
+
 function createPlayerTile(source) {
   const tile = document.createElement('div');
 
@@ -142,29 +165,6 @@ function createPlayerTile(source) {
   });
 
   return tile;
-}
-
-function getPlayerInstance(playerConfig, source) {
-  let player = reusablePlayers.find(player => player.getSource() === source);
-  if (player) {
-    // An active player instance already exists for this source
-    return player;
-  }
-
-  player = reusablePlayers.find(player => player.getSource() == null);
-  if (player) {
-    // Re-use one of the unused player instances
-    player.load(source);
-    return player;
-  }
-
-  // Create a new player instance
-  const container = createPlayerTile(source);
-  const newPlayer = new bitmovin.player.Player(container, playerConfig);
-  newPlayer.load(source);
-  reusablePlayers.push(newPlayer);
-
-  return newPlayer;
 }
 
 // Page listeners

--- a/multiview/multiplayer.js
+++ b/multiview/multiplayer.js
@@ -1,0 +1,167 @@
+const sources = [
+  { 
+    hls: 'https://cdn.bitmovin.com/content/sports-mashup/sports-mashup-hls/m3u8/master.m3u8',
+    poster: 'https://cdn.bitmovin.com/content/sports-mashup/poster.jpg',
+    title: 'Bitmovin Sports Mashup',
+  },
+  { 
+    dash: 'https://cdn.bitmovin.com/content/assets/MI201109210084/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+    poster: 'https://cdn.bitmovin.com/content/assets/poster/hd/RedBull.jpg',
+    title: 'Red Bull - Art of Motion',
+  },
+  // {
+  //   hls: 'https://cdn.bitmovin.com/content/sintel/hls/playlist.m3u8',
+  //   poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png',
+  //   title: 'Sintel',
+  // },
+  {
+    hls: 'https://bitmovin-player-eu-west1-ci-input.s3.amazonaws.com/general/hls/tears-of-steel/max-720p.m3u8',
+    poster: 'https://i.ytimg.com/vi/umNfA9m6Kis/hq720.jpg',
+    title: 'Tears of Steel',
+  },
+  {
+    dash: 'https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd',
+    poster: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRXQhf9eletYavf20COCj38YnLdm01cCJ-qyg&s',
+    title: 'Big Buck Bunny',
+  }
+];
+const playerConfig = {
+  key: 'YOUR_PLAYER_KEY',
+  buffer: { audio: { forwardduration: 12 }, video: { forwardduration: 12 } },
+  playback: { muted: true, autoplay: true },
+};
+
+var activeSources = [];
+var reusablePlayers = [];
+var draggedElement = null;
+
+const onPageLoad = () => {
+  populateCarousel();
+
+  // Pre-select the first item to showcase the feature
+  toggleCarouselItem(document.querySelector('.item'));
+}
+
+function populateCarousel() {
+  const carousel = document.getElementById('carousel');
+
+  for (let i = 0; i < sources.length; i++) {
+    const source = sources[i];
+    
+    const img = document.createElement('img');
+    img.src = source.poster;
+    img.alt = source.title;
+
+    const checkmark = document.createElement('span');
+    checkmark.className = 'checkmark';
+    checkmark.textContent = '✔';
+
+    const item = document.createElement('div');
+    item.className = 'item';
+    item.id = `${i}`;
+    item.addEventListener('click', () => toggleCarouselItem(item));
+
+    item.appendChild(img);
+    item.appendChild(checkmark);
+    carousel.appendChild(item);
+  }
+}
+
+const toggleCarouselItem = (item) => {
+  item.classList.toggle('selected');
+
+  const sourceId = parseInt(item.id);
+  const source = sources[sourceId];
+  const isSelected = item.classList.contains('selected');
+  if (isSelected) {
+    activeSources.push(source);
+  } else {
+    activeSources = activeSources.filter(active => {
+      const shouldKeep = active.title !== source.title;
+      if (!shouldKeep) {
+        // TODO: should we destroy the player instance?
+        const player = reusablePlayers.find(player => player.getSource() === source);
+        player && player.unload();
+      }
+      return shouldKeep;
+    });
+  }
+
+  updateGrid();
+}
+
+function updateGrid() {
+  const grid = document.getElementById('grid');
+  
+  // Clear existing tiles and classes
+  grid.innerHTML = '';
+  grid.className = 'grid';
+
+  // Add tiles dynamically
+  for (let i = 0; i < activeSources.length; i++) {
+    const source = activeSources[i];
+    const player = getPlayerInstance(playerConfig, source);
+
+    const tile = player.getContainer();
+    grid.appendChild(tile);
+  }
+
+  // Set grid layout using CSS classes
+  grid.classList.add(`tile-count-${activeSources.length}`);
+}
+
+function createPlayerTile(source) {
+  const tile = document.createElement('div');
+
+  tile.classList.add('tile');
+  tile.id = 'player'; 
+  tile.draggable = true;
+  tile.title = source.title;
+
+  tile.addEventListener("dragstart", event => {
+    if (event.target.id === 'player') {
+      draggedElement = event.target;
+    }
+  });
+  tile.addEventListener("dragover", (event) => {
+    event.preventDefault();
+  });
+  tile.addEventListener("drop", (event) => {
+    event.preventDefault();
+
+    const targetElement = event.target.closest('#player');
+    if (draggedElement == null || targetElement == null || draggedElement == targetElement) {
+      console.error('No target or same source');
+      return;
+    }
+
+    // Swap sources
+    const targetIndex = activeSources.findIndex(config => config.title === targetElement.title);
+    const sourceIndex = activeSources.findIndex(config => config.title === draggedElement.title);
+    const temp = activeSources[targetIndex];
+    activeSources[targetIndex] = activeSources[sourceIndex];
+    activeSources[sourceIndex] = temp;
+
+    updateGrid();
+  });
+
+  return tile;
+}
+
+function getPlayerInstance(playerConfig, source) {
+  const player = reusablePlayers.find(player => player.getSource() === source);
+  if (player) {
+    return player;
+  }
+
+  // Create a new player instance
+  const container = createPlayerTile(source);
+  const newPlayer = new bitmovin.player.Player(container, playerConfig);
+  newPlayer.load(source);
+  reusablePlayers.push(newPlayer);
+
+  return newPlayer;
+}
+
+// Page listeners
+window.addEventListener('load', () => onPageLoad());

--- a/multiview/multiplayer.js
+++ b/multiview/multiplayer.js
@@ -9,11 +9,6 @@ const sources = [
     poster: 'https://cdn.bitmovin.com/content/assets/poster/hd/RedBull.jpg',
     title: 'Red Bull - Art of Motion',
   },
-  // {
-  //   hls: 'https://cdn.bitmovin.com/content/sintel/hls/playlist.m3u8',
-  //   poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png',
-  //   title: 'Sintel',
-  // },
   {
     hls: 'https://bitmovin-player-eu-west1-ci-input.s3.amazonaws.com/general/hls/tears-of-steel/max-720p.m3u8',
     poster: 'https://i.ytimg.com/vi/umNfA9m6Kis/hq720.jpg',
@@ -79,7 +74,7 @@ const toggleCarouselItem = (item) => {
     activeSources = activeSources.filter(active => {
       const shouldKeep = active.title !== source.title;
       if (!shouldKeep) {
-        // TODO: should we destroy the player instance?
+        // Unload the player instance, so that it can be reused
         const player = reusablePlayers.find(player => player.getSource() === source);
         player && player.unload();
       }
@@ -138,6 +133,7 @@ function createPlayerTile(source) {
     // Swap sources
     const targetIndex = activeSources.findIndex(config => config.title === targetElement.title);
     const sourceIndex = activeSources.findIndex(config => config.title === draggedElement.title);
+    
     const temp = activeSources[targetIndex];
     activeSources[targetIndex] = activeSources[sourceIndex];
     activeSources[sourceIndex] = temp;
@@ -149,8 +145,16 @@ function createPlayerTile(source) {
 }
 
 function getPlayerInstance(playerConfig, source) {
-  const player = reusablePlayers.find(player => player.getSource() === source);
+  let player = reusablePlayers.find(player => player.getSource() === source);
   if (player) {
+    // An active player instance already exists for this source
+    return player;
+  }
+
+  player = reusablePlayers.find(player => player.getSource() == null);
+  if (player) {
+    // Re-use one of the unused player instances
+    player.load(source);
     return player;
   }
 

--- a/multiview/multiplayer.js
+++ b/multiview/multiplayer.js
@@ -10,15 +10,15 @@ const sources = [
     title: 'Red Bull - Art of Motion',
   },
   {
-    hls: 'https://bitmovin-player-eu-west1-ci-input.s3.amazonaws.com/general/hls/tears-of-steel/max-720p.m3u8',
-    poster: 'https://i.ytimg.com/vi/umNfA9m6Kis/hq720.jpg',
-    title: 'Tears of Steel',
+    dash: 'https://cdn.bitmovin.com/content/assets/bbb/stream.mpd',
+    poster: 'https://cdn.bitmovin.com/content/assets/poster/hd/BigBuckBunny.jpg',
+    title: 'Big Buck Bunny',
   },
   {
-    dash: 'https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd',
-    poster: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRXQhf9eletYavf20COCj38YnLdm01cCJ-qyg&s',
-    title: 'Big Buck Bunny',
-  }
+    dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
+    poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png',
+    title: 'Sintel',
+  },
 ];
 const playerConfig = {
   key: 'YOUR_PLAYER_KEY',

--- a/multiview/multiplayer.js
+++ b/multiview/multiplayer.js
@@ -34,7 +34,7 @@ const onPageLoad = () => {
   populateCarousel();
 
   // Pre-select the first item to showcase the feature
-  toggleCarouselItem(document.querySelector('.item'));
+  toggleCarouselItem(document.getElementById('0'));
 }
 
 function populateCarousel() {


### PR DESCRIPTION
This PR adds a sample showing how you could achieve a multiview experience using multiple Bitmovin Player instances.
The sample allows to add as many as 4 sources to the multiview. One player is always kept predominant but the players can also be swapped around, e.g. you can drag one of the active player to become the main one.
![Screenshot 2024-11-20 alle 14 13 20 (2)](https://github.com/user-attachments/assets/38beffbb-22be-4559-889b-6eb3c6272471)


Notes: 
- This sample uses the same page setup/background as other samples in this repository.
- Sources are temporary and need validation