### PR TITLE
Remove cache-busting URL parameter and remove unnecessary unregister

### DIFF
--- a/serviceworker/README.md
+++ b/serviceworker/README.md
@@ -11,3 +11,4 @@ This folder contains a sample page to test `ServiceWorker` support for Native HL
 
 - ServiceWorker only works for `localhost` and `https` protocol. So using `http` will not work
 - ServiceWorker enables support for event tracking for Native HLS playback i.e, Hls on Safari, without having duplicate manifest requests.
+- Use a stable service worker URL, such as `./sw.js`. Do not append dynamic query parameters (e.g. `'./sw.js?t=' + Date.now()`), as each unique URL creates a new registration and bypasses the browser's update mechanism. The player calls `registration.update()` during setup, so a stable URL always picks up worker updates. Manually unregistering service workers is not needed.

--- a/serviceworker/index.html
+++ b/serviceworker/index.html
@@ -70,7 +70,7 @@
       metadataparsed: console.warn,
     },
     location: {
-      serviceworker: './sw.js?t=' + Date.now()
+      serviceworker: './sw.js'
     },
     tweaks: {
       native_hls_parsing: true,

--- a/serviceworker/index.html
+++ b/serviceworker/index.html
@@ -51,14 +51,6 @@
   </div>
 </div>
 <script type="text/javascript">
-  function unregisterAllServiceWorker() {
-    return navigator.serviceWorker.getRegistrations().then((registrations) => {
-      return Promise
-      .all(registrations.map(registration => registration.unregister()))
-      .then(() => {});
-    });
-  }
-
   const conf = {
     key: 'YOUR KEY HERE',
     cast: {
@@ -83,12 +75,8 @@
 
   bitmovin.player.Player.addModule(bitmovin.player['serviceworker-client'].default);
 
-  var player;
-  unregisterAllServiceWorker().then(() => {
-    player = new bitmovin.player.Player(document.getElementById('player'), conf);
-
-    player.load(source).then(() => player.play());
-  });
+  var player = new bitmovin.player.Player(document.getElementById('player'), conf);
+  player.load(source).then(() => player.play());
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Description

The sample was passing `'./sw.js?t=' + Date.now()` as the service worker URL. The browser treats the full URL including query string as the SW's identity, so each player instance effectively tried to register a different script.

This pattern is dangerous to recommend as a sample: with multiple instances on the same page this causes the browser to refuse subsequent registrations - see point 4 [at serviceWorker's update](https://w3c.github.io/ServiceWorker/#update-algorithm) spec.

The `?t=` param is also redundant: browsers bypass the HTTP cache when checking the registered SW script for updates, and the player additionally calls `registration.update()` on every setup.

## Changes

- Use a stable `./sw.js` URL instead of a cache-busted one
- Remove the `unregisterAllServiceWorker()` workaround; it only existed to clean up the registrations the cache-buster leaked, and it unregistered every worker on the origin, including any a host app may own
- Document the stable-URL recommendation in the README
